### PR TITLE
Tt 7973 release 2.60.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.60.1.0 Unreleased
+
+* [TT-7269] - Update to version 2.60.1.0
+
 ## 2.60.0.0
 
 * [TT-7269] - Update to version 2.60.0.0

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "dius/pact-broker:2.59.2.0"
+    "Name": "dius/pact-broker:2.60.1.0"
   },
   "Ports": [
     {


### PR DESCRIPTION
### WHY

Updates pact-broker to the latest version which contains a publishing fix for our projects